### PR TITLE
Replace deprecated banst/awscli image with official and verified amazon image

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,7 +9,7 @@ services:
   app-node:
     depends_on:
       - dynamodb-local
-    image: banst/awscli
+    image: amazon/aws-cli
     container_name: app-node
     ports:
      - "8080:8080"


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:* replacing the deprecated banst/awscli image with the official and verified amazon image



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
