### PR TITLE
Remove hard-coded region

### DIFF
--- a/workshops/relational-migration/chalicelib/dynamodb_calls.py
+++ b/workshops/relational-migration/chalicelib/dynamodb_calls.py
@@ -13,10 +13,9 @@ deserializer = boto3.dynamodb.types.TypeDeserializer()
 serializer = boto3.dynamodb.types.TypeSerializer()
 
 return_limit = 20
-region = 'us-west-2'
 
-ddb = boto3.client('dynamodb', region_name=region)
-ddbr = boto3.resource('dynamodb', region_name=region)
+ddb = boto3.client('dynamodb')
+ddbr = boto3.resource('dynamodb')
 # resource vs client: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/programming-with-python.html#programming-with-python-client-resource
 
 serializer = TypeSerializer()

--- a/workshops/relational-migration/chalicelib/dynamodb_calls.py
+++ b/workshops/relational-migration/chalicelib/dynamodb_calls.py
@@ -13,9 +13,10 @@ deserializer = boto3.dynamodb.types.TypeDeserializer()
 serializer = boto3.dynamodb.types.TypeSerializer()
 
 return_limit = 20
+region = os.getenv('AWS_DEFAULT_REGION','us-west-2')
 
-ddb = boto3.client('dynamodb')
-ddbr = boto3.resource('dynamodb')
+ddb = boto3.client('dynamodb', region_name=region)
+ddbr = boto3.resource('dynamodb', region_name=region)
 # resource vs client: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/programming-with-python.html#programming-with-python-client-resource
 
 serializer = TypeSerializer()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
dynamodb_calls.py had the region hard coded to us-west-2. So the relational migration app will not find the DynamoDB tables if the lab is completed in a different region. This change removes the hard coded AWS region from the DynamoDB client and resource definitions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
