### PR TITLE
docs: remove deprecated Node.js SDK v2 from Operations.md

### DIFF
--- a/examples/SDK/node.js/Operations.md
+++ b/examples/SDK/node.js/Operations.md
@@ -1,63 +1,64 @@
-# Supported Operations - Table needs to be updated
+# Supported Operations
 
-| Operation                                           | Node.js SDK v3 | Node.js SDK v2 |
-| --------------------------------------------------- | :------------: | :------------: |
-| BatchGet                                            |       ✅       |       ❌       |
-| BatchWrite                                          |       ✅       |       ❌       |
-| DeleteItem                                          |       ✅       |       ❌       |
-| DeleteItemConditional                               |       ✅       |       ❌       |
-| GetItem                                             |       ✅       |       ❌       |
-| PutItem                                             |       ✅       |       ❌       |
-| PutItemConditional                                  |       ✅       |       ❌       |
-| TransactGet                                         |       ✅       |       ❌       |
-| TransactWrite                                       |       ✅       |       ❌       |
-| UpdateItem                                          |       ✅       |       ❌       |
-| UpdateItemConditional                               |       ✅       |       ❌       |
-| PartiQL SimpleSelectStatement                       |       ✅       |       ❌       |
-| PartiQL ExecuteStatement                            |       ✅       |       ❌       |
-| PartiQL ExecuteTransaction                          |       ✅       |       ❌       |
-| PartiQL BatchExecuteStatement                       |       ✅       |       ❌       |
-| Create Index                                        |       ✅       |       ❌       |
-| Update Index Provisioned Capacity                   |       ✅       |       ❌       |
-| Delete Index                                        |       ✅       |       ❌       |
-| Query Index                                         |       ❌       |       ❌       |
-| Consistent read                                     |       ✅       |       ❌       |
-| Count                                               |       ✅       |       ❌       |
-| Filter expression                                   |       ✅       |       ❌       |
-| Key condition and begins_with                       |       ✅       |       ❌       |
-| Key condition, begins_with, sort order              |       ✅       |       ❌       |
-| Key condition and between dates                     |       ✅       |       ❌       |
-| Key condition and between numbers                   |       ✅       |       ❌       |
-| Key condition and equals                            |       ✅       |       ❌       |
-| Key condition and greater or equals                 |       ✅       |       ❌       |
-| Key condition and greater than                      |       ✅       |       ❌       |
-| Key condition and less or equals                    |       ✅       |       ❌       |
-| Key condition and less                              |       ✅       |       ❌       |
-| Query with pagination                               |       ✅       |       ❌       |
-| Query with pagination - all data                    |       ✅       |       ❌       |
-| Query with backwards pagination                     |       ✅       |       ❌       |
-| Projection expression                               |       ✅       |       ❌       |
-| Scan with Pagination                                |       ✅       |       ❌       |
-| Scan Parallel Segments                              |       ✅       |       ❌       |
-| Read from stream                                    |       ✅       |       ❌       |
-| Add Global Table Region                             |       ✅       |       ❌       |
-| Add Provisioned Capacity                            |       ✅       |       ❌       |
-| CreateTable On-Demand                               |       ✅       |       ❌       |
-| CreateTable Provisioned                             |       ✅       |       ❌       |
-| Delete Global Table Region                          |       ✅       |       ❌       |
-| DeleteTable                                         |       ✅       |       ❌       |
-| DescribeGlobalTable and DescribeGlobalTableSettings |       ✅       |       ❌       |
-| DescribeLimits                                      |       ✅       |       ❌       |
-| DescribeTable                                       |       ✅       |       ❌       |
-| Disable Autoscaling                                 |       ✅       |       ❌       |
-| Enable Autoscaling                                  |       ❌       |       ✅       |
-| Update Autoscaling                                  |       ❌       |       ✅       |
-| Disable Streams                                     |       ✅       |       ❌       |
-| Enable Streams                                      |       ✅       |       ❌       |
-| ListTables                                          |       ✅       |       ❌       |
-| UpdateGlobalTable and UpdateGlobalTableSettings     |       ✅       |       ❌       |
-| UpdateTable On-Demand                               |       ✅       |       ❌       |
-| UpdateTable Provisioned                             |       ✅       |       ❌       |
-| Create an on-demand backup                          |       ✅       |       ❌       |
-| Delete backup                                       |       ✅       |       ❌       |
-| Describe backup                                     |       ✅       |       ❌       |
+| Operation                                           | Node.js SDK v3 |
+| --------------------------------------------------- | :------------: |
+| BatchGet                                            |       ✅       |
+| BatchWrite                                          |       ✅       |
+| DeleteItem                                          |       ✅       |
+| DeleteItemConditional                               |       ✅       |
+| GetItem                                             |       ✅       |
+| PutItem                                             |       ✅       |
+| PutItemConditional                                  |       ✅       |
+| TransactGet                                         |       ✅       |
+| TransactWrite                                       |       ✅       |
+| UpdateItem                                          |       ✅       |
+| UpdateItemConditional                               |       ✅       |
+| PartiQL SimpleSelectStatement                       |       ✅       |
+| PartiQL ExecuteStatement                            |       ✅       |
+| PartiQL ExecuteTransaction                          |       ✅       |
+| PartiQL BatchExecuteStatement                       |       ✅       |
+| Create Index                                        |       ✅       |
+| Update Index Provisioned Capacity                   |       ✅       |
+| Delete Index                                        |       ✅       |
+| Query Index                                         |       ❌       |
+| Consistent read                                     |       ✅       |
+| Count                                               |       ✅       |
+| Filter expression                                   |       ✅       |
+| Key condition and begins_with                       |       ✅       |
+| Key condition, begins_with, sort order              |       ✅       |
+| Key condition and between dates                     |       ✅       |
+| Key condition and between numbers                   |       ✅       |
+| Key condition and equals                            |       ✅       |
+| Key condition and greater or equals                 |       ✅       |
+| Key condition and greater than                      |       ✅       |
+| Key condition and less or equals                    |       ✅       |
+| Key condition and less                              |       ✅       |
+| Query with pagination                               |       ✅       |
+| Query with pagination - all data                    |       ✅       |
+| Query with backwards pagination                     |       ✅       |
+| Projection expression                               |       ✅       |
+| Scan with Pagination                                |       ✅       |
+| Scan Parallel Segments                              |       ✅       |
+| Read from stream                                    |       ✅       |
+| Add Global Table Region                             |       ✅       |
+| Add Provisioned Capacity                            |       ✅       |
+| CreateTable On-Demand                               |       ✅       |
+| CreateTable Provisioned                             |       ✅       |
+| Delete Global Table Region                          |       ✅       |
+| DeleteTable                                         |       ✅       |
+| DescribeGlobalTable and DescribeGlobalTableSettings |       ✅       |
+| DescribeLimits                                      |       ✅       |
+| DescribeTable                                       |       ✅       |
+| Disable Autoscaling                                 |       ✅       |
+| Enable Autoscaling                                  |       ✅       |
+| Update Autoscaling                                  |       ✅       |
+| Disable Streams                                     |       ✅       |
+| Enable Streams                                      |       ✅       |
+| ListTables                                          |       ✅       |
+| UpdateGlobalTable and UpdateGlobalTableSettings     |       ✅       |
+| UpdateTable On-Demand                               |       ✅       |
+| UpdateTable Provisioned                             |       ✅       |
+| Create an on-demand backup                          |       ✅       |
+| Delete backup                                       |       ✅       |
+| Describe backup                                     |       ✅       |
+


### PR DESCRIPTION
Fixes #123

This PR updates the Node.js Operations.md documentation to remove references to the deprecated AWS SDK for JavaScript v2 and align the Operations page with the supported JavaScript (v3) examples.

Changes:
- Removed outdated SDK v2 references from Operations.md.
- Ensured the Operations page points to the correct/maintained Node.js example versions.
