### PR TITLE
docs: add rust operations page

### DIFF
--- a/examples/SDK/rust/Operations.md
+++ b/examples/SDK/rust/Operations.md
@@ -1,1 +1,56 @@
 # Supported Operations - Table needs to be updated
+
+| Operation                                           | Rust SDK |
+| --------------------------------------------------- | :------: |
+| BatchGet                                            |    ✅    |
+| BatchWrite                                          |    ✅    |
+| DeleteItem                                          |    ✅    |
+| DeleteItemConditional                               |    ❌    |
+| GetItem                                             |    ✅    |
+| PutItem                                             |    ✅    |
+| PutItemConditional                                  |    ✅    |
+| TransactGet                                         |    ✅    |
+| TransactWrite                                       |    ✅    |
+| UpdateItem                                          |    ✅    |
+| UpdateItemConditional                               |    ✅    |
+| PartiQL SimpleSelectStatement                       |    ❌    |
+| PartiQL ExecuteStatement                            |    ❌    |
+| PartiQL ExecuteTransaction                          |    ❌    |
+| PartiQL BatchExecuteStatement                       |    ❌    |
+| ConsistentRead                                      |    ✅    |
+| FilterExpression                                    |    ✅    |
+| ProjectionExpression                                |    ✅    |
+| ReturnConsumedCapacity                              |    ✅    |
+| Simple Scan                                         |    ✅    |
+| Paginate Scan                                       |    ✅    |
+| Parallel Scan                                       |    ✅    |
+| Boto3 Paginator Scan                                |    ❌    |
+| FilterExpression (Scan)                             |    ❌    |
+| ProjectionExpression (Scan)                         |    ❌    |
+| Add Global Table Region                             |    ❌    |
+| Add Provisioned Capacity                            |    ❌    |
+| CreateGlobalTable                                   |    ❌    |
+| CreateTable On-Demand                               |    ✅    |
+| CreateTable Provisioned                             |    ❌    |
+| Delete Global Table Region                          |    ❌    |
+| DeleteTable                                         |    ✅    |
+| DescribeGlobalTable and DescribeGlobalTableSettings |    ❌    |
+| DescribeLimits                                      |    ❌    |
+| DescribeTable                                       |    ✅    |
+| Disable Autoscaling                                 |    ❌    |
+| Enable Autoscaling                                  |    ❌    |
+| Update Autoscaling                                  |    ❌    |
+| Disable Streams                                     |    ✅    |
+| Enable Streams                                      |    ✅    |
+| ListTables                                          |    ✅    |
+| UpdateGlobalTable and UpdateGlobalTableSettings     |    ❌    |
+| UpdateTable On-Demand                               |    ❌    |
+| UpdateTable Provisioned                             |    ❌    |
+| Pagination                                          |    ❌    |
+| Query Begins With                                   |    ❌    |
+| Query Scan Count                                    |    ✅    |
+| Query Equals                                        |    ✅    |
+| Add GSI                                             |    ✅    |
+| Enable Continuous Backups                           |    ❌    |
+| PartiQL QueryBatchExecuteStatement                  |    ❌    |
+| PartiQL PaginatedSelectStatement                    |    ❌    |


### PR DESCRIPTION
This PR creates the [Operations.md](cci:7://file:///c:/Users/pc/Documents/contribuicoes-open-source/aws-dynamodb-examples/examples/SDK/Operations.md:0:0-0:0) file for the Rust SDK, addressing issue #125.

### Changes
- Created [examples/SDK/rust/Operations.md](cci:7://file:///c:/Users/pc/Documents/contribuicoes-open-source/aws-dynamodb-examples/examples/SDK/rust/Operations.md:0:0-0:0) following the pattern of the Python SDK operations file.
- Audited existing Rust examples to correctly mark operations as supported (✅) or missing (❌).

### Verification
I verified the existence of examples for:
- Basic Item CRUD (including batch and transactions)
- Table operations (Create, List, Delete, Describe)
- Global Secondary Indexes
- Stream defaults (Enable/Disable)
- Scan variations

Ref: #125